### PR TITLE
Add composer.json and package.json files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "macopedia/table-of-contents",
+  "description": "CKEditor 4 Table of Contents plugin",
+  "keywords": ["ckeditor", "plugin", "toc"],
+  "homepage": "https://ckeditor.com/cke4/addon/contents",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "drunk"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/macopedia/Table-of-Contents/issues",
+    "source": "https://github.com/macopedia/Table-of-Contents.git"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@macopedia/table-of-contents",
+  "version": "0.12",
+  "description": "CKEditor 4 Table of Contents plugin",
+  "keywords": ["ckeditor", "plugin", "toc"],
+  "homepage": "https://ckeditor.com/cke4/addon/contents",
+  "bugs": {
+    "url": "https://github.com/macopedia/Table-of-Contents/issues"
+  },
+  "license" : "MIT",
+  "author": "drunk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/macopedia/Table-of-Contents.git"
+  }
+}


### PR DESCRIPTION
This adds the files necessary for use by PHP's composer and node's NPM package managers.

I've used macopedia/Table-of-Contents as the package name, as I don't think that rathax is interested in maintaining this.